### PR TITLE
feat: add labeled recent work carousel

### DIFF
--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -27,7 +27,7 @@ const Intro = () => {
       {/* Content */}
       <div className="space-y-8 max-w-4xl">
         <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-[1.1] tracking-tight text-balance">
-          Navigate your company's terrain with Nimble footwork.
+          Navigate your company&apos;s terrain with Nimble footwork.
         </h1>
         <h2 className="text-2xl md:text-3xl text-darkSecondary/80">
         A boutique AI launch & advisory firm

--- a/src/components/sections/RecentWork.tsx
+++ b/src/components/sections/RecentWork.tsx
@@ -1,45 +1,86 @@
-import React from "react";
+import React, { useState } from "react";
+
+const projects = [
+  {
+    label: "Product Development",
+    description:
+      "Building an intelligent order management for an FMCG distributor with 3k+ SKUs",
+  },
+  {
+    label: "Product Development",
+    description:
+      "Developed a generative AI reporting proof of concept for a global top ten bank",
+  },
+  {
+    label: "Product Development",
+    description:
+      "Built MVP report generation platform covering marketing strategy and customer sentiment documents",
+  },
+  {
+    label: "Enablement",
+    description:
+      "Providing advisory services to a surgeon on private practice operational efficiency",
+  },
+  {
+    label: "Enablement",
+    description:
+      "Providing advisory services to a boutique consulting firm helping them become thought leaders with LLMs",
+  },
+  {
+    label: "Enablement",
+    description:
+      "Ran workshops and customer journey mapping for startups on leveraging LLMs within their own products",
+  },
+];
 
 const RecentWork = () => {
+  const [index, setIndex] = useState(0);
+
+  const next = () => setIndex((prev) => (prev + 1) % projects.length);
+  const prev = () => setIndex((prev) => (prev - 1 + projects.length) % projects.length);
+
   return (
     <section className="max-w-7xl mx-auto px-12 py-12">
-      <h2 className="text-2xl md:text-3xl font-boska text-dark text-center mb-6">Recent Work</h2>
+      <h2 className="text-2xl md:text-3xl font-boska text-dark text-center mb-6">
+        Recent Work
+      </h2>
 
-      <div className="grid md:grid-cols-2 gap-8 md:gap-12 justify-center">
-        {/* Product Development Card */}
-        <div className="member bg-secondary bg-opacity-40 rounded-lg p-8 w-full flex flex-col items-stretch text-wrap justify-start text-left space-y-3">
-          <h3 className="text-lg md:text-xl font-bold mb-1 text-center md:text-center">Product Development</h3>
-          <ul className="text-sm text-opacity-80 space-y-3 px-1">
-            <li>
-              Building an intelligent order management for an FMCG distributor with 3k+ SKUs
-            </li>
-            <li>
-              Developed a generative AI reporting proof of concept for a global top ten bank
-            </li>
-            <li>
-              Built MVP report generation platform covering marketing strategy and customer sentiment documents
-            </li>
-          </ul>
+      <div className="relative">
+        <div className="overflow-hidden">
+          <div
+            className="flex transition-transform duration-500"
+            style={{ transform: `translateX(-${index * 100}%)` }}
+          >
+            {projects.map((project, i) => (
+              <div key={i} className="w-full flex-shrink-0 px-4">
+                <div className="member bg-secondary bg-opacity-40 rounded-lg p-8 w-full flex flex-col items-stretch text-wrap justify-start text-left space-y-3">
+                  <h3 className="text-lg md:text-xl font-bold mb-1 text-center md:text-center">
+                    {project.label}
+                  </h3>
+                  <p className="text-sm text-opacity-80 px-1">{project.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-
-        {/* Enablement Card */}
-        <div className="member bg-secondary bg-opacity-40 rounded-lg p-8 w-full flex flex-col items-stretch text-wrap justify-start text-left space-y-3">
-          <h3 className="text-lg md:text-xl font-bold mb-1 text-center md:text-center">Enablement</h3>
-          <ul className="text-sm text-opacity-80 space-y-3 px-1">
-            <li>
-              Providing advisory services to a surgeon on private practice operational efficiency
-            </li>
-            <li>
-              Providing advisory services to a boutique consulting firm helping them become thought leaders with LLMs
-            </li>
-            <li>
-              Ran workshops and customer journey mapping for startups on leveraging LLMs within their own products
-            </li>
-          </ul>
-        </div>
+        <button
+          aria-label="Previous project"
+          className="absolute left-0 top-1/2 -translate-y-1/2 bg-dark text-white px-3 py-1 rounded-full"
+          onClick={prev}
+        >
+          &#8592;
+        </button>
+        <button
+          aria-label="Next project"
+          className="absolute right-0 top-1/2 -translate-y-1/2 bg-dark text-white px-3 py-1 rounded-full"
+          onClick={next}
+        >
+          &#8594;
+        </button>
       </div>
     </section>
   );
 };
 
 export default RecentWork;
+

--- a/src/components/sections/RecentWork.tsx
+++ b/src/components/sections/RecentWork.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 
 const projects = [

--- a/src/components/sections/RecentWork.tsx
+++ b/src/components/sections/RecentWork.tsx
@@ -3,7 +3,7 @@
 import { data } from "autoprefixer";
 import React, { useState } from "react";
 
-const dataResponse = [
+const projects = [
   {
     label: "Product Development",
     description:
@@ -36,11 +36,6 @@ const dataResponse = [
   },
 ];
 
-//const projects = dataResponse.sort(randFunc);
-function randFunc(a, b) {  
-  return 0.5 - Math.random();
-} 
-const projects = dataResponse;
 
 const RecentWork = () => {
 

--- a/src/components/sections/RecentWork.tsx
+++ b/src/components/sections/RecentWork.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { data } from "autoprefixer";
 import React, { useState } from "react";
 
-const projects = [
+const dataResponse = [
   {
     label: "Product Development",
     description:
@@ -35,52 +36,41 @@ const projects = [
   },
 ];
 
-const RecentWork = () => {
-  const [index, setIndex] = useState(0);
+//const projects = dataResponse.sort(randFunc);
+function randFunc(a, b) {  
+  return 0.5 - Math.random();
+} 
+const projects = dataResponse;
 
-  const next = () => setIndex((prev) => (prev + 1) % projects.length);
-  const prev = () => setIndex((prev) => (prev - 1 + projects.length) % projects.length);
+const RecentWork = () => {
+
 
   return (
-    <section className="max-w-7xl mx-auto px-12 py-12">
-      <h2 className="text-2xl md:text-3xl font-boska text-dark text-center mb-6">
-        Recent Work
-      </h2>
+    <div className="py-8">
+      <h2 className="pageHeader text-center">Recent Work</h2>
 
-      <div className="relative">
-        <div className="overflow-hidden">
+      <div
+        className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8 md:mt-10
+                   max-w-6xl mx-auto"
+      >
+        {projects.map((project, index) => (
           <div
-            className="flex transition-transform duration-500"
-            style={{ transform: `translateX(-${index * 100}%)` }}
+            key={index}
+            className="bg-secondary/40 rounded-lg p-6
+                       flex flex-col items-center text-center
+                       min-h-[100px]" /* ensure consistent card height; adjust as needed */
           >
-            {projects.map((project, i) => (
-              <div key={i} className="w-full flex-shrink-0 px-4">
-                <div className="member bg-secondary bg-opacity-40 rounded-lg p-8 w-full flex flex-col items-stretch text-wrap justify-start text-left space-y-3">
-                  <h3 className="text-lg md:text-xl font-bold mb-1 text-center md:text-center">
-                    {project.label}
-                  </h3>
-                  <p className="text-sm text-opacity-80 px-1">{project.description}</p>
-                </div>
-              </div>
-            ))}
+            {/* TOP SECTION */}
+            <div className="space-y-2">
+              <p className="text-lg">{project.description}</p>
+            </div>
+            <p className="text-xs opacity-60 mt-auto pt-4 inline-flex justify-center">{project.label}</p>
+
+
           </div>
-        </div>
-        <button
-          aria-label="Previous project"
-          className="absolute left-0 top-1/2 -translate-y-1/2 bg-dark text-white px-3 py-1 rounded-full"
-          onClick={prev}
-        >
-          &#8592;
-        </button>
-        <button
-          aria-label="Next project"
-          className="absolute right-0 top-1/2 -translate-y-1/2 bg-dark text-white px-3 py-1 rounded-full"
-          onClick={next}
-        >
-          &#8594;
-        </button>
+        ))}
       </div>
-    </section>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Replace grid-based Recent Work section with a carousel so each project appears on its own slide with Product Development or Enablement labels
- Escape apostrophe in intro headline to satisfy lint rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a5a81eea64832aa74178160f65d5d3